### PR TITLE
Add csm-high-priority-service pod priority

### DIFF
--- a/kubernetes/cray-nexus/values.yaml
+++ b/kubernetes/cray-nexus/values.yaml
@@ -16,6 +16,7 @@ sonatype-nexus:
     type: Recreate
 
   nexus:
+    priorityClassName: "csm-high-priority-service"
     imageName: sonatype/nexus3
     imageTag: 3.25.0
     env:


### PR DESCRIPTION
### Summary and Scope

Update cray-nexus to support pod priorities

### Issues and Related PRs

* CASMPET-4264

### Testing

* vshasta

```
ncn-m001-6ef90a9f:/home/bklein # kubectl -n nexus get pod nexus-d6f7b88dc-s2smd -o yaml | grep prior
        f:priorityClassName: {}
  priority: 1000000
  priorityClassName: csm-high-priority-service
```

Was a fresh Install tested? N
Was an Upgrade tested?      Y
Was a Downgrade tested?     N
If schema changes were part of this change, how were those handled in your upgrade/downgrade testing? N/A

### Risks and Mitigations

Low

### Requires:

* Fresh install