### PR TITLE
CASMPET-5167 : Release cray-nexus for CSM 1.2

### DIFF
--- a/kubernetes/cray-nexus/Chart.yaml
+++ b/kubernetes/cray-nexus/Chart.yaml
@@ -2,7 +2,7 @@
 ---
 apiVersion: v1
 name: cray-nexus
-version: 0.7.0
+version: 0.8.0
 description: Sonatype Nexus is an open source repository manager
 appVersion: 3.25.0
 home: "spet/cray-charts"


### PR DESCRIPTION
Prep for release of cray-nexus for CSM 1.2 which will include the following
* CASMPET-4951 : BI-CAN: Update nexus to use the new API Gateways