### PR TITLE
Casmpet 5135 keycloak integration

### DIFF
--- a/kubernetes/cray-nexus/templates/job-init.yaml
+++ b/kubernetes/cray-nexus/templates/job-init.yaml
@@ -49,7 +49,6 @@ spec:
             nexus-enable-anonymous-access >&2
             nexus-remove-default-repos >&2
             nexus-enable-rut-auth >&2
-            nexus-enable-keycloak-realm >&2
 
             {{- if .Values.init.adminCredentials.enabled }}
             echo "$NEXUS_ADMIN_PASSWORD" | nexus-change-password admin >&2

--- a/kubernetes/cray-nexus/templates/job-init.yaml
+++ b/kubernetes/cray-nexus/templates/job-init.yaml
@@ -49,6 +49,7 @@ spec:
             nexus-enable-anonymous-access >&2
             nexus-remove-default-repos >&2
             nexus-enable-rut-auth >&2
+            nexus-enable-keycloak-realm >&2
 
             {{- if .Values.init.adminCredentials.enabled }}
             echo "$NEXUS_ADMIN_PASSWORD" | nexus-change-password admin >&2

--- a/kubernetes/cray-nexus/values.yaml
+++ b/kubernetes/cray-nexus/values.yaml
@@ -66,6 +66,12 @@ sonatype-nexus:
     - name: nexus-config
       configMap:
         name: nexus-config
+    - name: ca-public-key
+      configMap:
+        name: cray-configmap-ca-public-key
+    additionalVolumeMounts:
+    - mountPath: /ca_public_key
+      name: ca-public-key
     initContainers:
     - name: init-data
       image: dtr.dev.cray.com/baseos/busybox:1
@@ -85,6 +91,8 @@ sonatype-nexus:
         name: nexus-data
       - mountPath: /nexus-config
         name: nexus-config
+      - mountPath: /ca_public_key
+        name: ca-public-key
 
   service:
     enabled: true
@@ -160,7 +168,7 @@ init:
   enabled: true
   image:
     repository: dtr.dev.cray.com/cray/cray-nexus-setup
-    tag: 0.3.2
+    tag: 0.5.3
     pullPolicy: IfNotPresent
   adminCredentials:
     enabled: false

--- a/kubernetes/cray-nexus/values.yaml
+++ b/kubernetes/cray-nexus/values.yaml
@@ -161,12 +161,6 @@ istio:
         authority: nexus.local
         routes:
         - port: 80
-      #    headers:
-      #      request:
-      #        add:
-      #          X-WEBAUTH-USER: admin
-      #        remove:
-      #        - Authorization
 
 init:
   enabled: true

--- a/kubernetes/cray-nexus/values.yaml
+++ b/kubernetes/cray-nexus/values.yaml
@@ -21,7 +21,7 @@ sonatype-nexus:
     imageTag: 3.25.0
     env:
     # See https://help.sonatype.com/repomanager3/installation/system-requirements#SystemRequirements-Memory
-    - name: install4jAddVmParams
+    - name: INSTALL4J_ADD_VM_PARAMS
       value: "-Xms4G -Xmx4G -XX:MaxDirectMemorySize=39158M -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap -Djavax.net.ssl.trustStore=/nexus-data/cacerts"
     - name: NEXUS_SECURITY_RANDOMPASSWORD
       value: "false"
@@ -151,18 +151,19 @@ istio:
                 X-WEBAUTH-USER: admin
               remove:
               - Authorization
-      # UI ingress should come from keycloak-gatekeeper
+      # Do not use the X-WEBAUTH-USER header because login credentials
+      # are verified by the Nexus Keycloak plugin.
       ui:
         enabled: false
         authority: nexus.local
         routes:
         - port: 80
-          headers:
-            request:
-              add:
-                X-WEBAUTH-USER: admin
-              remove:
-              - Authorization
+      #    headers:
+      #      request:
+      #        add:
+      #          X-WEBAUTH-USER: admin
+      #        remove:
+      #        - Authorization
 
 init:
   enabled: true

--- a/kubernetes/cray-nexus/values.yaml
+++ b/kubernetes/cray-nexus/values.yaml
@@ -22,9 +22,24 @@ sonatype-nexus:
     env:
     # See https://help.sonatype.com/repomanager3/installation/system-requirements#SystemRequirements-Memory
     - name: install4jAddVmParams
-      value: "-Xms4G -Xmx4G -XX:MaxDirectMemorySize=39158M -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap"
+      value: "-Xms4G -Xmx4G -XX:MaxDirectMemorySize=39158M -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap -Djavax.net.ssl.trustStore=/nexus-data/cacerts"
     - name: NEXUS_SECURITY_RANDOMPASSWORD
       value: "false"
+    - name: KC_AUTH_URL
+      valueFrom:
+        secretKeyRef:
+          key: endpoint
+          name: system-nexus-client-auth
+    - name: KC_CLIENT_ID
+      valueFrom:
+        secretKeyRef:
+          key: client-id
+          name: system-nexus-client-auth
+    - name: KC_CLIENT_CRED
+      valueFrom:
+        secretKeyRef:
+          key: client-secret
+          name: system-nexus-client-auth
     resources:
       requests:
         cpu: "4"
@@ -45,6 +60,8 @@ sonatype-nexus:
       helm.sh/resource-policy: keep
 
   deployment:
+    postStart:
+      command: ["/usr/local/bin/initialize-keycloak-plugin"]
     additionalVolumes:
     - name: nexus-config
       configMap:


### PR DESCRIPTION
## Summary and Scope

These changes add the correct chart configuration for enabling the Nexus Keycloak authentication integration.  

## Issues and Related PRs

* Resolves CASMPET-5135

## Testing

This chart has been installed multiple times on Mug and it has been confirmed that the expected configuration is created to support configuring and running the plugin. 

### Tested on:

  * Mug
  * Virtual Shasta

### Test description:

On VShasta the plugin was confirmed to work in the case of a new installation and on Mug it was confirmed that it is possible to update an existing Nexus instance with this image.

Confirmed that the base image contains the expected plugin and that the configuration required to enable the plugin works as expected. Note that this image was also tested in the context of Helm and the cray-nexus chart.

Confirmed that Keycloak authentication, RUT, and internal authentication via the UI works as expected and that curl access to the Nexus API continues to work at this time.

## Risks and Mitigations

None


