### PR TITLE
CASMTRIAGE-3126 Update cray-nexus-setup

### DIFF
--- a/kubernetes/cray-nexus/Chart.yaml
+++ b/kubernetes/cray-nexus/Chart.yaml
@@ -1,8 +1,30 @@
-# Copyright 2020, Cray Inc.
+#
+# MIT License
+#
+# (C) Copyright 2020-2022 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
 ---
 apiVersion: v2
 name: cray-nexus
-version: 0.10.0
+version: 0.10.1
 description: Sonatype Nexus is an open source repository manager
 keywords:
   - sonatype

--- a/kubernetes/cray-nexus/values.yaml
+++ b/kubernetes/cray-nexus/values.yaml
@@ -1,4 +1,26 @@
-# Copyright 2022 Hewlett Packard Enterprise Development LP
+#
+# MIT License
+#
+# (C) Copyright 2020-2022 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
 
 # Base sonatype-nexus chart values
 # See https://github.com/Oteemo/charts/tree/master/charts/sonatype-nexus#configuration
@@ -161,7 +183,7 @@ setup:
   enabled: true
   image:
     repository: artifactory.algol60.net/csm-docker/stable/cray-nexus-setup
-    tag: 0.6.0
+    tag: 0.6.1
     pullPolicy: IfNotPresent
   adminCredential:
     enabled: true


### PR DESCRIPTION
## Summary and Scope

This updates the cray-nexus chart to use the latest version of the cray-nexus-setup.

## Issues and Related PRs

* CASMTRIAGE-3126

## Testing

### Tested on:

  * Virtual Shasta

### Test description:

The existing chart (0.10.0) was upgraded (to 0.10.1) and a new chart was installed to confirm there were no issues.

## Risks and Mitigations

None