### PR TITLE
CASMPET-5591: Update the image location

### DIFF
--- a/kubernetes/cray-nexus/Chart.yaml
+++ b/kubernetes/cray-nexus/Chart.yaml
@@ -24,7 +24,7 @@
 ---
 apiVersion: v2
 name: cray-nexus
-version: 0.10.1
+version: 0.10.2
 description: Sonatype Nexus is an open source repository manager
 keywords:
   - sonatype
@@ -41,6 +41,6 @@ dependencies:
 maintainers:
   - name: rnoska-hpe
 icon: https://raw.githubusercontent.com/sonatype/nexus-public/release-3.25.0-03/components/nexus-rapture/src/main/resources/static/rapture/resources/icons/x100/nexus-black.png
-appVersion: 3.25.0-2
+appVersion: 3.25.0
 annotations:
   artifacthub.io/license: MIT

--- a/kubernetes/cray-nexus/Chart.yaml
+++ b/kubernetes/cray-nexus/Chart.yaml
@@ -44,3 +44,6 @@ icon: https://raw.githubusercontent.com/sonatype/nexus-public/release-3.25.0-03/
 appVersion: 3.25.0
 annotations:
   artifacthub.io/license: MIT
+  artifacthub.io/images: |
+    - name: nexus3
+      image: artifactory.algol60.net/csm-docker/stable/docker.io/sonatype/nexus3:3.25.0

--- a/kubernetes/cray-nexus/values.yaml
+++ b/kubernetes/cray-nexus/values.yaml
@@ -38,8 +38,8 @@ sonatype-nexus:
 
   nexus:
     priorityClassName: "csm-high-priority-service"
-    imageName: artifactory.algol60.net/csm-docker/stable/nexus3
-    imageTag: 3.25.0-2
+    imageName: artifactory.algol60.net/csm-docker/stable/docker.io/sonatype/nexus3
+    imageTag: 3.25.0
     env:
     # See https://help.sonatype.com/repomanager3/installation/system-requirements#SystemRequirements-Memory
     - name: INSTALL4J_ADD_VM_PARAMS
@@ -85,7 +85,7 @@ sonatype-nexus:
       mountPath: /ca_public_key
     initContainers:
     - name: init
-      image: artifactory.algol60.net/csm-docker/stable/nexus3:3.25.0-2
+      image: artifactory.algol60.net/csm-docker/stable/docker.io/sonatype/nexus3:3.25.0
       command:
       - /bin/sh
       - -c


### PR DESCRIPTION
## Summary and Scope

This changes the location of the nexus3 image. It is in a process to move the location of the image build from the nexus3 repository to the container-images repository. The image being pulled adds no new or changing function only rebuild location as the nexus3 repository no longer can rebuild the image properly.

## Issues and Related PRs

* Resolves [CASMPET-5591](https://jira-pro.its.hpecorp.net:8443/browse/CASMPET-5591)
* Future work required by [CASMPET-5592](https://jira-pro.its.hpecorp.net:8443/browse/CASMPET-5592)

## Testing

### Tested on:

  * Local development environment
  * Virtual Shasta

### Test description:

Tested by running on vshasta by logging into nexus via the keycloak integration.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why? y
- Was downgrade tested? If not, why? y
- Were new tests (or test issues/Jiras) created for this change? n

## Risks and Mitigations

No known risk to this change

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

