### PR TITLE
CASMPET-5397: Upgrade the image version of nexus

### DIFF
--- a/kubernetes/cray-nexus/Chart.yaml
+++ b/kubernetes/cray-nexus/Chart.yaml
@@ -41,9 +41,9 @@ dependencies:
 maintainers:
   - name: rnoska-hpe
 icon: https://raw.githubusercontent.com/sonatype/nexus-public/release-3.38.0-01/components/nexus-rapture/src/main/resources/static/rapture/resources/icons/x100/nexus-black.png
-appVersion: 3.38.0
+appVersion: 3.38.0-1
 annotations:
   artifacthub.io/license: MIT
   artifacthub.io/images: |
     - name: nexus3
-      image: artifactory.algol60.net/csm-docker/stable/docker.io/sonatype/nexus3:3.38.0
+      image: artifactory.algol60.net/csm-docker/stable/docker.io/sonatype/nexus3:3.38.0-1

--- a/kubernetes/cray-nexus/Chart.yaml
+++ b/kubernetes/cray-nexus/Chart.yaml
@@ -24,7 +24,7 @@
 ---
 apiVersion: v2
 name: cray-nexus
-version: 0.10.2
+version: 0.11.0
 description: Sonatype Nexus is an open source repository manager
 keywords:
   - sonatype
@@ -40,10 +40,10 @@ dependencies:
     repository: https://oteemo.github.io/charts/
 maintainers:
   - name: rnoska-hpe
-icon: https://raw.githubusercontent.com/sonatype/nexus-public/release-3.25.0-03/components/nexus-rapture/src/main/resources/static/rapture/resources/icons/x100/nexus-black.png
-appVersion: 3.25.0
+icon: https://raw.githubusercontent.com/sonatype/nexus-public/release-3.38.0-01/components/nexus-rapture/src/main/resources/static/rapture/resources/icons/x100/nexus-black.png
+appVersion: 3.38.0
 annotations:
   artifacthub.io/license: MIT
   artifacthub.io/images: |
     - name: nexus3
-      image: artifactory.algol60.net/csm-docker/stable/docker.io/sonatype/nexus3:3.25.0
+      image: artifactory.algol60.net/csm-docker/stable/docker.io/sonatype/nexus3:3.38.0

--- a/kubernetes/cray-nexus/values.yaml
+++ b/kubernetes/cray-nexus/values.yaml
@@ -39,7 +39,7 @@ sonatype-nexus:
   nexus:
     priorityClassName: "csm-high-priority-service"
     imageName: artifactory.algol60.net/csm-docker/stable/docker.io/sonatype/nexus3
-    imageTag: 3.38.0
+    imageTag: 3.38.0-1
     env:
     # See https://help.sonatype.com/repomanager3/installation/system-requirements#SystemRequirements-Memory
     - name: INSTALL4J_ADD_VM_PARAMS
@@ -85,7 +85,7 @@ sonatype-nexus:
       mountPath: /ca_public_key
     initContainers:
     - name: init
-      image: artifactory.algol60.net/csm-docker/stable/docker.io/sonatype/nexus3:3.38.0
+      image: artifactory.algol60.net/csm-docker/stable/docker.io/sonatype/nexus3:3.38.0-1
       command:
       - /bin/sh
       - -c

--- a/kubernetes/cray-nexus/values.yaml
+++ b/kubernetes/cray-nexus/values.yaml
@@ -39,7 +39,7 @@ sonatype-nexus:
   nexus:
     priorityClassName: "csm-high-priority-service"
     imageName: artifactory.algol60.net/csm-docker/stable/docker.io/sonatype/nexus3
-    imageTag: 3.25.0
+    imageTag: 3.38.0
     env:
     # See https://help.sonatype.com/repomanager3/installation/system-requirements#SystemRequirements-Memory
     - name: INSTALL4J_ADD_VM_PARAMS
@@ -85,7 +85,7 @@ sonatype-nexus:
       mountPath: /ca_public_key
     initContainers:
     - name: init
-      image: artifactory.algol60.net/csm-docker/stable/docker.io/sonatype/nexus3:3.25.0
+      image: artifactory.algol60.net/csm-docker/stable/docker.io/sonatype/nexus3:3.38.0
       command:
       - /bin/sh
       - -c


### PR DESCRIPTION
## Summary and Scope

This change will update the nexus image to a much more recent version released. The change is not easily downgraded however documentation updates will allow for ability to rollback. The only change in this nexus update is to bring the image up to a version that is much newer. The impact is low and there has been much testing to ensure update works well as well as upgrade.

## Issues and Related PRs

* Resolves [CASMPET-5397](https://jira-pro.its.hpecorp.net:8443/browse/CASMPET-5397)
* Future work required by [CASMPET-5397](https://jira-pro.its.hpecorp.net:8443/browse/CASMPET-5397)
* Documentation changes required in [CASMPET-5646](https://jira-pro.its.hpecorp.net:8443/browse/CASMPET-5646)

## Testing

### Tested on:

  * Drax - Full backup upgrade and restore
  * Surtur - Just backup and restore
  * Virtual Shasta

### Test description:

- Was upgrade tested? If not, why? y
- Was downgrade tested? If not, why? y
- Were new tests (or test issues/Jiras) created for this change? y

## Risks and Mitigations

The only risk is with a return to old versions. That is solved by using the export/restore procedure that will be written up in CASMPET-5646


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

