### PR TITLE
CASM-4669 Upgrade Nexus to 3.67.1 to support image signatures

### DIFF
--- a/kubernetes/cray-nexus/Chart.yaml
+++ b/kubernetes/cray-nexus/Chart.yaml
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2020-2022 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2020-2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -24,7 +24,7 @@
 ---
 apiVersion: v2
 name: cray-nexus
-version: 0.11.1
+version: 0.12.0
 description: Sonatype Nexus is an open source repository manager
 keywords:
   - sonatype
@@ -40,10 +40,10 @@ dependencies:
     repository: https://oteemo.github.io/charts/
 maintainers:
   - name: rnoska-hpe
-icon: https://raw.githubusercontent.com/sonatype/nexus-public/release-3.38.0-01/components/nexus-rapture/src/main/resources/static/rapture/resources/icons/x100/nexus-black.png
-appVersion: 3.38.0-1
+icon: https://raw.githubusercontent.com/sonatype/nexus-public/release-3.67.1-01/components/nexus-rapture/src/main/resources/static/rapture/resources/icons/x100/nexus-black.png
+appVersion: 3.67.1-1
 annotations:
   artifacthub.io/license: MIT
   artifacthub.io/images: |
     - name: nexus3
-      image: artifactory.algol60.net/csm-docker/stable/docker.io/sonatype/nexus3:3.38.0-1
+      image: artifactory.algol60.net/csm-docker/stable/docker.io/sonatype/nexus3:3.67.1-1

--- a/kubernetes/cray-nexus/values.yaml
+++ b/kubernetes/cray-nexus/values.yaml
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2020-2022 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2020-2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -39,7 +39,7 @@ sonatype-nexus:
   nexus:
     priorityClassName: "csm-high-priority-service"
     imageName: artifactory.algol60.net/csm-docker/stable/docker.io/sonatype/nexus3
-    imageTag: 3.38.0-1
+    imageTag: 3.67.1-1
     env:
     # See https://help.sonatype.com/repomanager3/installation/system-requirements#SystemRequirements-Memory
     - name: INSTALL4J_ADD_VM_PARAMS
@@ -85,7 +85,7 @@ sonatype-nexus:
       mountPath: /ca_public_key
     initContainers:
     - name: init
-      image: artifactory.algol60.net/csm-docker/stable/docker.io/sonatype/nexus3:3.38.0-1
+      image: artifactory.algol60.net/csm-docker/stable/docker.io/sonatype/nexus3:3.67.1-1
       command:
       - /bin/sh
       - -c


### PR DESCRIPTION
## Summary and Scope

For mage signature support, we need to upgrade Nexus to latest version. Previous version 3.38.0 can handle either multi-platform images (aka "manifest lists"), or sigstore attachments for regular manifests, but not both. Tested version 3.67.1 which appears to be working fine.

## Issues and Related PRs

* Needed by  [CASM-4669](https://jira-pro.it.hpe.com:8443/browse/CASM-4669)

## Testing
### Tested on:

  * Virtual Shasta

### Test description:

* Loaded unstable image into k8s cluster running on vShasta environment.
* Verified that Keycloak auth realm is still working and configurable
* Verified that multi-platform images can be uploaded with signatures

## Risks and Mitigations
Low - new release only
