### PR TITLE
CASMPET-7068 Upgrade Nexus to 3.68.1

### DIFF
--- a/kubernetes/cray-nexus/Chart.yaml
+++ b/kubernetes/cray-nexus/Chart.yaml
@@ -24,7 +24,7 @@
 ---
 apiVersion: v2
 name: cray-nexus
-version: 0.12.1
+version: 0.12.2
 description: Sonatype Nexus is an open source repository manager
 keywords:
   - sonatype
@@ -40,10 +40,10 @@ dependencies:
     repository: https://oteemo.github.io/charts/
 maintainers:
   - name: rnoska-hpe
-icon: https://raw.githubusercontent.com/sonatype/nexus-public/release-3.67.1-01/components/nexus-rapture/src/main/resources/static/rapture/resources/icons/x100/nexus-black.png
-appVersion: 3.67.1-1
+icon: https://raw.githubusercontent.com/sonatype/nexus-public/main/components/nexus-rapture/src/main/resources/static/rapture/resources/icons/x100/nexus-black.png
+appVersion: 3.68.1-1
 annotations:
   artifacthub.io/license: MIT
   artifacthub.io/images: |
     - name: nexus3
-      image: artifactory.algol60.net/csm-docker/stable/docker.io/sonatype/nexus3:3.67.1-1
+      image: artifactory.algol60.net/csm-docker/stable/docker.io/sonatype/nexus3:3.68.1-1

--- a/kubernetes/cray-nexus/values.yaml
+++ b/kubernetes/cray-nexus/values.yaml
@@ -39,7 +39,7 @@ sonatype-nexus:
   nexus:
     priorityClassName: "csm-high-priority-service"
     imageName: artifactory.algol60.net/csm-docker/stable/docker.io/sonatype/nexus3
-    imageTag: 3.67.1-1
+    imageTag: 3.68.1-1
     env:
     # See https://help.sonatype.com/repomanager3/installation/system-requirements#SystemRequirements-Memory
     - name: INSTALL4J_ADD_VM_PARAMS
@@ -85,7 +85,7 @@ sonatype-nexus:
       mountPath: /ca_public_key
     initContainers:
     - name: init
-      image: artifactory.algol60.net/csm-docker/stable/docker.io/sonatype/nexus3:3.67.1-1
+      image: artifactory.algol60.net/csm-docker/stable/docker.io/sonatype/nexus3:3.68.1-1
       command:
       - /bin/sh
       - -c


### PR DESCRIPTION
## Summary and Scope

Need to upgrade Nexus to 3.68.1 - vulnerability reported for versions up to 3.68.0: https://support.sonatype.com/hc/en-us/articles/29416509323923-CVE-2024-4956-Nexus-Repository-3-Path-Traversal-2024-05-16?_ga=2.111591940.162078004.1716391739-1182997560.1716391642

## Issues and Related PRs

* Resolves [CASMPET-7068](https://jira-pro.it.hpe.com:8443/browse/CASMPET-7068)

## Risks and Mitigations

Low - 1.6 only, will rollback if any issues occur.