### PR TITLE
CASMPET-6707: Add a pre-install hook that waits for system-nexus-client-auth secret to exist

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-(C) Copyright [2020] Hewlett Packard Enterprise Development LP
+(C) Copyright [2020-2024] Hewlett Packard Enterprise Development LP
 
 Permission is hereby granted, free of charge, to any person obtaining a
 copy of this software and associated documentation files (the "Software"),

--- a/kubernetes/cray-nexus/Chart.yaml
+++ b/kubernetes/cray-nexus/Chart.yaml
@@ -24,7 +24,7 @@
 ---
 apiVersion: v2
 name: cray-nexus
-version: 0.12.2
+version: 0.13.0
 description: Sonatype Nexus is an open source repository manager
 keywords:
   - sonatype

--- a/kubernetes/cray-nexus/online-overrides.yaml
+++ b/kubernetes/cray-nexus/online-overrides.yaml
@@ -1,3 +1,27 @@
+#
+# MIT License
+#
+# (C) Copyright 2020-2024 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+
 # Example Nexus Repository Manager (NXRM) configuration that adds proxy and
 # group "docker" repositories to the default airgap setup provided by
 # cray-nexus-setup.
@@ -29,13 +53,13 @@ charts:
         hosts:
           registry:
             routes:
-	      # Writes goto port 5003 (default registry). NXRM does not (as of
-	      # yet) support pushing to group repositories, see
-	      # https://issues.sonatype.org/browse/NEXUS-10471. Until then, a
-	      # port must be exposed in order to enable images to be pushed to
-	      # this registry. See also, https://stackoverflow.com/a/54590014
-	      # which describes using a reverse proxy to direct writes to the
-	      # desired registry.
+              # Writes goto port 5003 (default registry). NXRM does not (as of
+              # yet) support pushing to group repositories, see
+              # https://issues.sonatype.org/browse/NEXUS-10471. Until then, a
+              # port must be exposed in order to enable images to be pushed to
+              # this registry. See also, https://stackoverflow.com/a/54590014
+              # which describes using a reverse proxy to direct writes to the
+              # desired registry.
               - match:
                 - method:
                     exact: HEAD

--- a/kubernetes/cray-nexus/templates/hook-serviceaccounts.yaml
+++ b/kubernetes/cray-nexus/templates/hook-serviceaccounts.yaml
@@ -1,0 +1,71 @@
+#
+# MIT License
+#
+# (C) Copyright 2024 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+
+{{- if .Values.security.keycloak.enabled }}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: "{{ .Values.hooks.preInstall.serviceAccountName }}"
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    helm.sh/hook: pre-install, pre-upgrade
+    helm.sh/hook-delete-policy: before-hook-creation, hook-succeeded
+    helm.sh/hook-weight: "-5"
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: "{{ .Values.hooks.preInstall.serviceAccountName }}-role"
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    helm.sh/hook: pre-install, pre-upgrade
+    helm.sh/hook-delete-policy: before-hook-creation, hook-succeeded
+    helm.sh/hook-weight: "-5"
+rules:
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "list", "watch"]
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: "{{ .Values.hooks.preInstall.serviceAccountName }}-rolebinding"
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    helm.sh/hook: pre-install, pre-upgrade
+    helm.sh/hook-delete-policy: before-hook-creation, hook-succeeded
+    helm.sh/hook-weight: "-5"
+subjects:
+  - kind: ServiceAccount
+    name: "{{ .Values.hooks.preInstall.serviceAccountName }}"
+    namespace: nexus
+roleRef:
+  kind: Role
+  name: "{{ .Values.hooks.preInstall.serviceAccountName }}-role"
+  apiGroup: rbac.authorization.k8s.io
+
+{{- end }}

--- a/kubernetes/cray-nexus/templates/hooks.yaml
+++ b/kubernetes/cray-nexus/templates/hooks.yaml
@@ -1,3 +1,66 @@
+#
+# MIT License
+#
+# (C) Copyright 2020-2024 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+
+{{- if .Values.security.keycloak.enabled }}
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ template "cray-nexus.fullname" . }}-secret-check
+  namespace: {{ .Release.Namespace }}
+  labels:
+{{ include "cray-nexus.labels" . | indent 4 }}
+  annotations:
+    helm.sh/hook: pre-install, pre-upgrade
+    helm.sh/hook-delete-policy: before-hook-creation, hook-succeeded
+spec:
+  template:
+    metadata:
+      annotations:
+        sidecar.istio.io/inject: "false"
+    spec:
+      serviceAccountName: "{{ .Values.hooks.preInstall.serviceAccountName }}"
+      restartPolicy: Never
+      containers:
+        - name: secret-check
+          image: "{{ .Values.hooks.preInstall.image.repository }}:{{ .Values.hooks.preInstall.image.tag }}"
+          imagePullPolicy: "{{ .Values.hooks.preInstall.image.pullPolicy }}"
+          command:
+          - /bin/sh
+          - -c
+          - |-
+            set -x
+
+            echo "Looking for secret {{ .Values.security.keycloak.client.secret.name }} ..."
+            # Wait for secret to exist in nexus namespace
+            while ! kubectl get secrets -n {{ .Release.Namespace }} {{ .Values.security.keycloak.client.secret.name }} >/dev/null; do
+                echo >&2 "Looking for secret {{ .Values.security.keycloak.client.secret.name }} again in 10 seconds."
+                sleep 10
+            done
+            echo "Found secret {{ .Values.security.keycloak.client.secret.name }}!"
+
+{{- end }}
 {{- if .Values.setup.enabled }}
 {{- if .Values.setup.adminCredential.enabled }}
 ---

--- a/kubernetes/cray-nexus/values.yaml
+++ b/kubernetes/cray-nexus/values.yaml
@@ -183,11 +183,19 @@ setup:
   enabled: true
   image:
     repository: artifactory.algol60.net/csm-docker/stable/cray-nexus-setup
-    tag: 0.11.0
+    tag: 0.11.1
     pullPolicy: IfNotPresent
   adminCredential:
     enabled: true
     secret: nexus-admin-credential
+
+hooks:
+  preInstall:
+    image:
+      repository: artifactory.algol60.net/csm-docker/stable/docker-kubectl
+      tag: 1.24.17
+      pullPolicy: IfNotPresent
+    serviceAccountName: nexus-pre-install
 
 security:
   anonymousAccess:


### PR DESCRIPTION
## Summary and Scope
- Add a pre-install hook that waits for system-nexus-client-auth secret to exist
- Add license to online-overrides.yaml and remove tabs.

Added a pre-install and pre-upgrade helm hook that checks for the existence of the `system-nexus-client-auth` secret since it is used to create the the `nexus-keycloak-realm-config`.

 ## Issues and Related PRs
* Resolves [CASMPET-6707](https://jira-pro.it.hpe.com:8443/browse/CASMPET-6707)

## Testing
Tested both pre-install and pre-upgrade paths with and without the `system-nexus-client-auth` secret.  If the secret doesn't exist, the hook will continue to wait until it is found or the helm pre-install/pre-upgrade time limit expires.  If the time limit is hit, the helm install/upgrade will fail.

Rolled back to original `cray-nexus` version after upgrade test.
Upgraded to original `cray-nexus` version after install test.
 
### Tested on:
  * `beau` vShasta system

## Risks and Mitigations
If the secret isn't found within the helm pre-install/pre-upgrade time limit, the install/upgrade will fail.  If we don't want this behavior, I can add a counter to limit the wait time.  Then, the install/upgrade will continue and if the secret does not exist, the UUID will be used to create the `nexus-keycloak-realm-config` which is what we're trying to prevent.


## Pull Request Checklist
- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable

