### PR TITLE
CASMTRIAGE-8587 cray-nexus deployment fails on nexus-init post-install hook

### DIFF
--- a/kubernetes/cray-nexus/Chart.yaml
+++ b/kubernetes/cray-nexus/Chart.yaml
@@ -24,7 +24,7 @@
 ---
 apiVersion: v2
 name: cray-nexus
-version: 0.14.1
+version: 0.14.2
 description: Sonatype Nexus is an open source repository manager
 keywords:
   - sonatype

--- a/kubernetes/cray-nexus/values.yaml
+++ b/kubernetes/cray-nexus/values.yaml
@@ -183,7 +183,7 @@ setup:
   enabled: true
   image:
     repository: artifactory.algol60.net/csm-docker/stable/cray-nexus-setup
-    tag: 0.12.1
+    tag: 0.12.2
     pullPolicy: IfNotPresent
   adminCredential:
     enabled: true


### PR DESCRIPTION
## Summary and Scope

Bump version of `cray-nexus-setup` image to mitigate [CASMTRIAGE-8587](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-8587). This PR is subsequent to https://github.com/Cray-HPE/nexus-setup/pull/35.

## Issues and Related PRs

* Resolves [CASMTRIAGE-8587](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-8587)

## Testing

_List the environments in which these changes were tested._

### Tested on:

  * `<development system>`
  * Local development environment
  * Virtual Shasta

### Test description:

_How were the changes tested and success verified? If schema changes were part of this change, how were those handled in your upgrade/downgrade testing?_

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why?
- Was downgrade tested? If not, why?
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

_Are there known issues with these changes? Any other special considerations?_


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

