### PR TITLE
CASMTRIAGE-8622: Update nexus-set-admin-password to not double check nexus is ready

### DIFF
--- a/kubernetes/cray-nexus/Chart.yaml
+++ b/kubernetes/cray-nexus/Chart.yaml
@@ -24,7 +24,7 @@
 ---
 apiVersion: v2
 name: cray-nexus
-version: 0.14.2
+version: 0.14.3
 description: Sonatype Nexus is an open source repository manager
 keywords:
   - sonatype

--- a/kubernetes/cray-nexus/templates/hooks.yaml
+++ b/kubernetes/cray-nexus/templates/hooks.yaml
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2020-2024 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2020-2025 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -112,9 +112,7 @@ spec:
             . "$(command -v nexus-ready)"
 
             # Change default admin password, as necessary
-            if curl -sfk "${URL}/v1/status/check"; then
-                echo "$NEXUS_ADMIN_PASSWORD" | nexus-change-password admin >&2
-            fi
+            echo "$NEXUS_ADMIN_PASSWORD" | nexus-change-password admin >&2
 
 {{- end }}
 ---


### PR DESCRIPTION
## Summary and Scope

This is a bugfix

## Issues and Related PRs

* Resolves [CASMTRIAGE-8622](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-8622)

## Testing

### Tested on:

  * beau

### Test description:

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?y
- Were continuous integration tests run? If not, why?y
- Was upgrade tested? If not, why?y
- Was downgrade tested? If not, why?y
- Were new tests (or test issues/Jiras) created for this change?y

## Risks and Mitigations

Does not add risk, nexus is already checked to be ready by the time this is called and then it is checked again in the function being called. So there is no reason to check if nexus is ready a third time that is less reliable output.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

