### PR TITLE
CASMTRIAGE-8670: Improve error checking on change password

### DIFF
--- a/kubernetes/cray-nexus/Chart.yaml
+++ b/kubernetes/cray-nexus/Chart.yaml
@@ -24,7 +24,7 @@
 ---
 apiVersion: v2
 name: cray-nexus
-version: 0.14.3
+version: 0.14.4
 description: Sonatype Nexus is an open source repository manager
 keywords:
   - sonatype

--- a/kubernetes/cray-nexus/templates/hooks.yaml
+++ b/kubernetes/cray-nexus/templates/hooks.yaml
@@ -118,9 +118,15 @@ spec:
                 sleep 10
             done
 
-            # Change default admin password, as necessary (this will only return 200 if the password is not changed)
-            if curl -sfk "${URL}/v1/status/check"; then
+            # change default admin password, as necessary
+            return_code=$(curl -sk -w "%{http_code}" "${url}/v1/status/check")
+            if [ "${return_code}" == "401" ]; then
+                echo "Nexus password is already changed"
+            elif [ "${return_code}" == "200" ]; then
                 echo "$NEXUS_ADMIN_PASSWORD" | nexus-change-password admin >&2
+            else
+                echo >&2 "Error: Nexus API not ready, returned ${return_code}"
+                return 1
             fi
 
 {{- end }}


### PR DESCRIPTION
## Summary and Scope

This is a bugfix

## Issues and Related PRs

* Resolves [CASMTRIAGE-8670](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-8670)

## Testing

### Tested on:

  * beau

### Test description:

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?y
- Were continuous integration tests run? If not, why?y
- Was upgrade tested? If not, why?y
- Was downgrade tested? If not, why?y
- Were new tests (or test issues/Jiras) created for this change?y

## Risks and Mitigations

Does not add risk, nexus is already checked to be ready by the time this is called and then it is checked again in the function being called. So there is no reason to check if nexus is ready a third time that is less reliable output.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

