### PR TITLE
CASMTRIAGE-8684: Fix URL in nexus-set-admin-password

### DIFF
--- a/kubernetes/cray-nexus/Chart.yaml
+++ b/kubernetes/cray-nexus/Chart.yaml
@@ -24,7 +24,7 @@
 ---
 apiVersion: v2
 name: cray-nexus
-version: 0.14.4
+version: 0.14.5
 description: Sonatype Nexus is an open source repository manager
 keywords:
   - sonatype

--- a/kubernetes/cray-nexus/templates/hooks.yaml
+++ b/kubernetes/cray-nexus/templates/hooks.yaml
@@ -119,7 +119,7 @@ spec:
             done
 
             # change default admin password, as necessary
-            return_code=$(curl -sk -w "%{http_code}" "${url}/v1/status/check")
+            return_code=$(curl -sk -w "%{http_code}" "${URL}/v1/status/check")
             if [ "${return_code}" == "401" ]; then
                 echo "Nexus password is already changed"
             elif [ "${return_code}" == "200" ]; then


### PR DESCRIPTION
## Summary and Scope

Bug where the URL in the nexus-set-admin-password is not correct so it never changes the password.

## Issues and Related PRs

* Resolves [CASMTRIAGE-8684](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-8684)

## Testing

### Tested on:

  * beau

### Test description:

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?y
- Were continuous integration tests run? If not, why?y
- Was upgrade tested? If not, why?y
- Was downgrade tested? If not, why?y
- Were new tests (or test issues/Jiras) created for this change?y

## Risks and Mitigations

less risk fixing a bug


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

