### PR TITLE
CASMTRIAGE-8684: Fix other issues with the URL

### DIFF
--- a/kubernetes/cray-nexus/Chart.yaml
+++ b/kubernetes/cray-nexus/Chart.yaml
@@ -24,7 +24,7 @@
 ---
 apiVersion: v2
 name: cray-nexus
-version: 0.14.5
+version: 0.14.6
 description: Sonatype Nexus is an open source repository manager
 keywords:
   - sonatype

--- a/kubernetes/cray-nexus/templates/hooks.yaml
+++ b/kubernetes/cray-nexus/templates/hooks.yaml
@@ -114,19 +114,20 @@ spec:
             # Make sure the rest of the nexus apis are ready
             while [[ "$(curl -sk -w '%{http_code}' -o /dev/null "${URL}/v1/status/check")" -gt 500 ]]
             do
+                echo >&2 "${URL}/v1/status/check is not ready"
                 echo >&2 "Trying again in 10 seconds"
                 sleep 10
             done
 
             # change default admin password, as necessary
-            return_code=$(curl -sk -w "%{http_code}" "${URL}/v1/status/check")
+            return_code=$(curl -sk -w "%{http_code}" -o /dev/null "${URL}/v1/status/check")
             if [ "${return_code}" == "401" ]; then
                 echo "Nexus password is already changed"
             elif [ "${return_code}" == "200" ]; then
                 echo "$NEXUS_ADMIN_PASSWORD" | nexus-change-password admin >&2
             else
                 echo >&2 "Error: Nexus API not ready, returned ${return_code}"
-                return 1
+                exit 1
             fi
 
 {{- end }}


### PR DESCRIPTION
## Summary and Scope

Bug where the URL in the nexus-set-admin-password is not correct so it never changes the password.
And there was an output bug in the http code check. And added more clear logging.

## Issues and Related PRs

* Resolves [CASMTRIAGE-8684](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-8684)

## Testing

### Tested on:

  * beau

### Test description:

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?y
- Were continuous integration tests run? If not, why?y
- Was upgrade tested? If not, why?y
- Was downgrade tested? If not, why?y
- Were new tests (or test issues/Jiras) created for this change?y

## Risks and Mitigations

less risk fixing a bug


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

